### PR TITLE
Add type hint to prevent reflection

### DIFF
--- a/src/tripod/context.cljc
+++ b/src/tripod/context.cljc
@@ -12,7 +12,7 @@
   #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
 ;; TODO: liter this through the call sites below.  This will allow pattern match on the results
-(defn- exception->ex-info [exception execution-id interceptor stage]
+(defn- exception->ex-info [^Throwable exception execution-id interceptor stage]
   (ex-info (str "Interceptor Exception: " #?(:clj  (.getMessage exception)
                                              :cljs (.-message exception)))
            (merge {:execution-id execution-id


### PR DESCRIPTION
When adding support for babashka in [martian](https://github.com/oliyh/martian/commit/f0f7679364f58eb4ef558e9ad2340274b9742542#diff-f5b0993235bb3d5b92e3dc2ab30e237361740648e356ac8616e0d3323c4359eaR12-R25) I had to patch this function because the reflective usage of `.getMessage` gave problems. Would you be open to receive this improvement as part of this library?